### PR TITLE
Fix dashboard when there are no testimonials

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -53,8 +53,7 @@ const Dashboard = () => {
   }, [testimonials]);
 
   return (
-    testimonials?.length > 0 && (
-      <div>
+    <div>
         <div className='w-full h-15 relative flex  items-center px-6 z-10  rounded-4xl  mt-2 '>
           <Navbar setOpen={setOpen} />
         </div>
@@ -68,7 +67,11 @@ const Dashboard = () => {
 
         {!showTestimonialForm && (
           <div className='mt-10'>
-            <TestimonialsGrid testimonials={testimonials} />
+            {testimonials.length > 0 ? (
+              <TestimonialsGrid testimonials={testimonials} />
+            ) : (
+              <p className='text-center text-white'>No testimonials yet.</p>
+            )}
           </div>
         )}
 
@@ -79,7 +82,6 @@ const Dashboard = () => {
           />
         )}
       </div>
-    )
   );
 };
 


### PR DESCRIPTION
## Summary
- render dashboard UI even when testimonials list is empty

## Testing
- `npm run lint` *(fails: next not found)*
- `npx tsc -p tsconfig.json` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6845f2520ec4832881bd7c47318ac936